### PR TITLE
Fix a build failure on Apple Clang 17.0.0 related to the distance calculation in js_string_convert_pos

### DIFF
--- a/mquickjs.c
+++ b/mquickjs.c
@@ -1473,7 +1473,11 @@ static uint32_t js_string_convert_pos(JSContext *ctx, JSValue val, uint32_t pos,
     for(ce_idx = 0; ce_idx < JS_STRING_POS_CACHE_SIZE; ce_idx++) {
         ce1 = &ctx->string_pos_cache[ce_idx];
         if (ce1->str == val) {
-            d = abs(ce1->str_pos[pos_type] - pos);
+            if (ce1->str_pos[pos_type] > pos) {
+                d = ce1->str_pos[pos_type] - pos;
+            } else {
+                d = pos - ce1->str_pos[pos_type];
+            }
             if (d < d_min) {
                 d_min = d;
                 ce = ce1;


### PR DESCRIPTION
The code previously called abs() on the result of an unsigned subtraction (uint32_t). 
While the code relied on underflow and implicit casting to int to function, Clang flags this as having no effect (or undefined behavior).

Compiler Error:

```
gcc -Wall -g -MMD -Werror -D_GNU_SOURCE -fno-math-errno -fno-trapping-math -Os -c -o mquickjs.o mquickjs.c
mquickjs.c:1476:17: error: taking the absolute value of unsigned type 'uint32_t' (aka 'unsigned int') has no effect [-Werror,-Wabsolute-value]
 1476 |             d = abs(ce1->str_pos[pos_type] - pos);
      |                 ^
mquickjs.c:1476:17: note: remove the call to 'abs' since unsigned values cannot be negative
 1476 |             d = abs(ce1->str_pos[pos_type] - pos);
      |                 ^~~
1 error generated.
make: *** [mquickjs.o] Error 1
```

Resolution: Replaced the abs() call with a manual conditional subtraction to correctly calculate the distance between the two unsigned positions without relying on implicit casts or underflow.