### PR TITLE
Fix: ignoring return value of 'fread' declared with attribute 'warn_unused_result'

### DIFF
--- a/example.c
+++ b/example.c
@@ -241,7 +241,10 @@ static uint8_t *load_file(const char *filename, int *plen)
     buf_len = ftell(f);
     fseek(f, 0, SEEK_SET);
     buf = malloc(buf_len + 1);
-    fread(buf, 1, buf_len, f);
+    if (fread(buf, 1, buf_len, f) != buf_len) {
+        printf("not read %d bytes\n", buf_len);
+        exit(1);
+    }
     buf[buf_len] = '\0';
     fclose(f);
     if (plen)

--- a/mqjs.c
+++ b/mqjs.c
@@ -250,7 +250,10 @@ static uint8_t *load_file(const char *filename, int *plen)
     buf_len = ftell(f);
     fseek(f, 0, SEEK_SET);
     buf = malloc(buf_len + 1);
-    fread(buf, 1, buf_len, f);
+    if (fread(buf, 1, buf_len, f) != buf_len) {
+        printf("not read %d bytes\n", buf_len);
+        exit(1);
+    }
     buf[buf_len] = '\0';
     fclose(f);
     if (plen)


### PR DESCRIPTION
When  I try to `make` the project using GCC 13.3.0, I get the following errors about ignoring the return result of `fread` in the `load_file` functions in `mqjs.c` and `example.c`:

```
gcc -Wall -g -MMD -Werror -D_GNU_SOURCE -fno-math-errno -fno-trapping-math -Os -c -o mqjs.o mqjs.c
mqjs.c: In function ‘load_file’:
mqjs.c:253:5: error: ignoring return value of ‘fread’ declared with attribute ‘warn_unused_result’ [-Werror=unused-result]
  253 |     fread(buf, 1, buf_len, f);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:109: mqjs.o] Error 1
```

And

```
gcc -Wall -g -MMD -Werror -D_GNU_SOURCE -fno-math-errno -fno-trapping-math -Os -c -o example.o example.c
example.c: In function ‘load_file’:
example.c:244:5: error: ignoring return value of ‘fread’ declared with attribute ‘warn_unused_result’ [-Werror=unused-result]
  244 |     fread(buf, 1, buf_len, f);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:109: example.o] Error 1
```

This PR fixes that by exiting if `buf_len` bytes are not read.
