### PR TITLE
Do difference calculation using signed integers in string position calculation

### DIFF
--- a/mquickjs.c
+++ b/mquickjs.c
@@ -1473,7 +1473,7 @@ static uint32_t js_string_convert_pos(JSContext *ctx, JSValue val, uint32_t pos,
     for(ce_idx = 0; ce_idx < JS_STRING_POS_CACHE_SIZE; ce_idx++) {
         ce1 = &ctx->string_pos_cache[ce_idx];
         if (ce1->str == val) {
-            d = abs(ce1->str_pos[pos_type] - pos);
+            d = abs((int32_t)ce1->str_pos[pos_type] - (int32_t)pos);
             if (d < d_min) {
                 d_min = d;
                 ce = ce1;


### PR DESCRIPTION
Apple compilers will complain about abs not doing anything if you leave these as unsigned.

This is a potential fix for https://github.com/bellard/mquickjs/issues/11