### PR TITLE
Check `RegExp` type in `js_regexp_get_flags`

### DIFF
--- a/mquickjs.c
+++ b/mquickjs.c
@@ -17612,6 +17612,8 @@ JSValue js_regexp_get_flags(JSContext *ctx, JSValue *this_val,
                             int argc, JSValue *argv)
 {
     JSRegExp *re = js_get_regexp(ctx, *this_val);
+    if (!re)
+        return JS_EXCEPTION;
     JSByteArray *arr;
     size_t len;
     char buf[RE_FLAG_COUNT + 1];


### PR DESCRIPTION
I'm attempting to extract your `RegExp` engine as a standalone library (to accompany my [regular expression research](https://github.com/thaliaarchi/regexp-museum)) and noticed this issue. All other `js_regexp_*` functions check the return value of `js_get_regexp`.

Separately, is it an issue for `argv` to be dereferenced without checking `argc`? It appears that `argv` is padded with `undefined` up to the arity of the function. The `RegExp` methods aren't variadic, so this should be fine. But I haven't traced all the control flow through the JS engine.

https://github.com/bellard/mquickjs/blob/0bbe1636ca003564bf6a3f6021bd728e1d722fa9/mquickjs.c#L5486-L5495