### PR TITLE
Fix parser reading past buffer bounds in next_token

### DIFF
--- a/mquickjs.c
+++ b/mquickjs.c
@@ -8020,7 +8020,11 @@ static void next_token(JSParseState *s)
     p = s->source_buf + s->buf_pos;
  redo:
     s->token.source_pos = p - s->source_buf;
-    c = *p;
+    /* Check buffer bounds - treat end of buffer as EOF (input may not be null-terminated) */
+    if (s->token.source_pos >= s->buf_len)
+        c = 0;
+    else
+        c = *p;
     switch(c) {
     case 0:
         s->token.val = TOK_EOF;


### PR DESCRIPTION
`JS_Eval` accepts explicit length but parser assumes null-terminated input. When buffer ends, treat as EOF (c=0) instead of reading past bounds. Uses normal EOF path so `buf_pos` is updated correctly.

Note: Lookahead reads (p[1], p[2] for multi-char operators) still assume valid input. This fix handles EOF, not malformed input.